### PR TITLE
chore(ci) : fail CI on deprecated TypeScript API

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default defineConfig([
   },
   {
     files: ['**/*.{ts,mts,cts}'],
-    extends: [tseslint.configs.recommendedTypeChecked],
+    extends: [tseslint.configs.recommended],
     languageOptions: {
       parserOptions: {
         project: './tsconfig.json',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,10 +7,19 @@ import tseslint from 'typescript-eslint';
 export default defineConfig([
   { ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.js', '*.config.ts'] },
   {
-    files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
+    files: ['**/*.{js,mjs,cjs}'],
     plugins: { js },
     extends: ['js/recommended'],
     languageOptions: { globals: globals.node },
+  },
+  {
+    files: ['**/*.{ts,mts,cts}'],
+    extends: [tseslint.configs.recommendedTypeChecked],
+    languageOptions: {
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    },
     rules: {
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -20,8 +29,8 @@ export default defineConfig([
           caughtErrorsIgnorePattern: '^_',
         },
       ],
+      '@typescript-eslint/no-deprecated': 'error',
     },
   },
-  tseslint.configs.recommended,
   prettier,
 ]);

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test": "NODE_ENV=test vitest run --coverage",
     "build": "rm -rf dist && tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "serve": "node dist/index.js",
-    "lint": "eslint . --ext .ts,.tsx,.js,.mjs,.cjs",
-    "lint:fix": "eslint . --ext .ts,.tsx,.js,.mjs,.cjs --fix",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #111 |

We needed to configure ESLint to detect usage of deprecated TypeScript symbols and fail CI when deprecated APIs are used.

- Separated the configuration into distinct sections for JavaScript and TypeScript files to enable type-aware linting specifically for TypeScript.
- Added the @typescript-eslint/no-deprecated rule set to 'error' to ensure linting fails on deprecated API usage.
- npm run lint fails when deprecated symbols are used.


@imdhemy could you please check and merge this pr. thanks!