### PR TITLE
chore(mongodb): preserve setup boundaries

### DIFF
--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -1,4 +1,5 @@
 import { assertIsNonEmptyString } from '@/modules/shared/kernel/assert';
+import { workspacesCollectionName } from '@/modules/shared/persistence/mongodb/workspaces-collection-schema';
 
 const connectionString = process.env.MONGODB_CONNECTION_STRING;
 assertIsNonEmptyString(connectionString, 'MONGODB_CONNECTION_STRING is not defined in environment variables');
@@ -7,7 +8,7 @@ export const mongodbConfig = {
   connectionString,
   indexes: [
     {
-      collectionName: 'workspaces',
+      collectionName: workspacesCollectionName,
       keys: { slug: 1 },
       options: { unique: true },
     },

--- a/src/modules/shared/persistence/mongodb/ensure-mongo-indexes.ts
+++ b/src/modules/shared/persistence/mongodb/ensure-mongo-indexes.ts
@@ -1,5 +1,4 @@
 import { type CreateIndexesOptions, type Db, type IndexSpecification } from 'mongodb';
-import { type RuntimeInfrastructureTask } from '@/modules/setup/infrastructure/ensure-runtime-infrastructure';
 
 type MongoIndexConfig = Readonly<{
   collectionName: string;
@@ -12,7 +11,7 @@ type EnsureMongoIndexesDependencies = Readonly<{
   indexes: readonly MongoIndexConfig[];
 }>;
 
-export function ensureMongoIndexes({ database, indexes }: EnsureMongoIndexesDependencies): RuntimeInfrastructureTask {
+export function ensureMongoIndexes({ database, indexes }: EnsureMongoIndexesDependencies): () => Promise<void> {
   return async () => {
     await Promise.all(
       indexes.map(async ({ collectionName, keys, options }) => {


### PR DESCRIPTION
| Q       | A          |
| ------- | ---------- |
| License | GPLv3      |
| Issue   | Follow-up to #124 |

### Summary

- keep shared Mongo index provisioning independent from setup module types
- use the workspace collection schema name in Mongo index config