### PR TITLE
Establish control-plane workspace context

### DIFF
--- a/src/modules/shared/control-plane/index.ts
+++ b/src/modules/shared/control-plane/index.ts
@@ -1,0 +1,2 @@
+export { workspaceContextFromRequest } from './workspace-context';
+export type { WorkspaceContext } from './workspace-context';

--- a/src/modules/shared/control-plane/workspace-context.test.ts
+++ b/src/modules/shared/control-plane/workspace-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { workspaceContextFromRequest } from '@/modules/shared/control-plane/workspace-context';
+
+describe('Workspace context', () => {
+  it('uses workspace context already attached to the request', () => {
+    const context = workspaceContextFromRequest({
+      context: {
+        workspace: {
+          workspaceId: 'workspace-from-context',
+        },
+      },
+      body: {
+        workspace_id: 'workspace-from-body',
+      },
+    });
+
+    expect(context).toEqual({
+      workspaceId: 'workspace-from-context',
+    });
+  });
+
+  it('can derive workspace context from a control-plane header', () => {
+    const context = workspaceContextFromRequest({
+      headers: {
+        'x-workspace-id': 'workspace-from-header',
+      },
+    });
+
+    expect(context).toEqual({
+      workspaceId: 'workspace-from-header',
+    });
+  });
+
+  it('can derive workspace context from path parameters', () => {
+    const context = workspaceContextFromRequest({
+      params: {
+        workspaceId: 'workspace-from-path',
+      },
+    });
+
+    expect(context).toEqual({
+      workspaceId: 'workspace-from-path',
+    });
+  });
+
+  it('does not trust workspace ownership from request body input', () => {
+    const context = workspaceContextFromRequest({
+      body: {
+        workspace_id: 'workspace-from-body',
+      },
+    });
+
+    expect(context).toBeUndefined();
+  });
+});

--- a/src/modules/shared/control-plane/workspace-context.ts
+++ b/src/modules/shared/control-plane/workspace-context.ts
@@ -16,7 +16,7 @@ type WorkspaceContextRequest = Readonly<{
 }>;
 
 function firstHeaderValue(value: HeaderValue): string | undefined {
-  return Array.isArray(value) ? value[0] : value;
+  return typeof value === 'string' ? value : value?.[0];
 }
 
 function contextFromWorkspaceId(workspaceId: string | undefined): WorkspaceContext | undefined {

--- a/src/modules/shared/control-plane/workspace-context.ts
+++ b/src/modules/shared/control-plane/workspace-context.ts
@@ -1,0 +1,40 @@
+export interface WorkspaceContext {
+  workspaceId: string;
+}
+
+type HeaderValue = string | readonly string[] | undefined;
+
+type WorkspaceContextRequest = Readonly<{
+  body?: unknown;
+  context?: Readonly<{
+    workspace?: WorkspaceContext;
+    workspaceContext?: WorkspaceContext;
+    workspaceId?: string;
+  }>;
+  headers?: Readonly<Record<string, HeaderValue>>;
+  params?: Readonly<Record<string, string | undefined>>;
+}>;
+
+function firstHeaderValue(value: HeaderValue): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function contextFromWorkspaceId(workspaceId: string | undefined): WorkspaceContext | undefined {
+  if (workspaceId === undefined) return undefined;
+
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (normalizedWorkspaceId.length === 0) return undefined;
+
+  return { workspaceId: normalizedWorkspaceId };
+}
+
+export function workspaceContextFromRequest(request: WorkspaceContextRequest): WorkspaceContext | undefined {
+  return (
+    request.context?.workspace ??
+    request.context?.workspaceContext ??
+    contextFromWorkspaceId(request.context?.workspaceId) ??
+    contextFromWorkspaceId(firstHeaderValue(request.headers?.['x-workspace-id'])) ??
+    contextFromWorkspaceId(request.params?.workspaceId) ??
+    contextFromWorkspaceId(request.params?.workspace_id)
+  );
+}


### PR DESCRIPTION
| Q       | A            |
| ------- | ------------ |
| License | GPLv3        |
| Issue   | Closes #136  |

## Context

This PR establishes the temporary workspace-context contract for control-plane operations while JWT-backed workspace authentication remains deferred. The intent is to give downstream workspace-owned features one explicit place to receive workspace ownership, so later auth work can strengthen how that context is derived without reshaping every application operation.

Review this as the base of the stack: the important question is whether the boundary is narrow enough, explicit enough, and avoids trusting arbitrary request-body ownership.