### PR TITLE
Add source data isolation guardrails

### DIFF
--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -1,4 +1,5 @@
 import { assertIsNonEmptyString } from '@/modules/shared/kernel/assert';
+import { sourcesCollectionName } from '@/modules/shared/persistence/mongodb/sources-collection-schema';
 import { workspacesCollectionName } from '@/modules/shared/persistence/mongodb/workspaces-collection-schema';
 
 const connectionString = process.env.MONGODB_CONNECTION_STRING;
@@ -10,6 +11,11 @@ export const mongodbConfig = {
     {
       collectionName: workspacesCollectionName,
       keys: { slug: 1 },
+      options: { unique: true },
+    },
+    {
+      collectionName: sourcesCollectionName,
+      keys: { workspace_id: 1, name: 1, environment: 1 },
       options: { unique: true },
     },
   ],

--- a/src/modules/shared/persistence/mongodb/index.ts
+++ b/src/modules/shared/persistence/mongodb/index.ts
@@ -1,4 +1,5 @@
 export { ensureMongoIndexes } from './ensure-mongo-indexes';
-export { mongoDBClient, usersCollection, workspacesCollection } from './mongodb-composition';
+export { mongoDBClient, sourcesCollection, usersCollection, workspacesCollection } from './mongodb-composition';
+export type { SourcesCollection } from './sources-collection-schema';
 export type { UsersCollection } from './users-collection-schema';
 export type { WorkspacesCollection } from './workspaces-collection-schema';

--- a/src/modules/shared/persistence/mongodb/mongodb-composition.ts
+++ b/src/modules/shared/persistence/mongodb/mongodb-composition.ts
@@ -1,5 +1,9 @@
 import { createMongodbClient } from '@/modules/shared/persistence/mongodb/create-mongodb-client';
 import {
+  type SourcesCollection,
+  sourcesCollectionName,
+} from '@/modules/shared/persistence/mongodb/sources-collection-schema';
+import {
   type UsersCollection,
   usersCollectionName,
 } from '@/modules/shared/persistence/mongodb/users-collection-schema';
@@ -12,6 +16,8 @@ import { mongodbConfig } from '@/config/mongodb';
 export const mongoDBClient = createMongodbClient({
   uri: mongodbConfig.connectionString,
 });
+
+export const sourcesCollection: SourcesCollection = mongoDBClient.db().collection(sourcesCollectionName);
 
 export const usersCollection: UsersCollection = mongoDBClient.db().collection(usersCollectionName);
 

--- a/src/modules/shared/persistence/mongodb/sources-collection-schema.ts
+++ b/src/modules/shared/persistence/mongodb/sources-collection-schema.ts
@@ -1,0 +1,14 @@
+import { type Collection, type ObjectId, type OptionalId } from 'mongodb';
+
+export interface SourceCollectionSchema {
+  _id: ObjectId;
+  description: string;
+  environment: string;
+  label: string;
+  name: string;
+  workspace_id: string;
+}
+
+export type SourcesCollection = Collection<OptionalId<SourceCollectionSchema>>;
+
+export const sourcesCollectionName = 'sources';

--- a/src/modules/source/domain/errors.ts
+++ b/src/modules/source/domain/errors.ts
@@ -1,0 +1,9 @@
+export interface SourceNameEnvironmentConflictError {
+  type: 'SOURCE_NAME_ENVIRONMENT_CONFLICT';
+  message: 'Source name already exists in this workspace environment';
+}
+
+export const sourceNameEnvironmentConflictError: SourceNameEnvironmentConflictError = {
+  type: 'SOURCE_NAME_ENVIRONMENT_CONFLICT',
+  message: 'Source name already exists in this workspace environment',
+};

--- a/src/modules/source/domain/source-repository.ts
+++ b/src/modules/source/domain/source-repository.ts
@@ -1,0 +1,11 @@
+import type { Result } from '@/modules/shared/kernel/result';
+import type { WorkspaceContext } from '@/modules/shared/control-plane';
+import type { SourceNameEnvironmentConflictError } from '@/modules/source/domain/errors';
+import type { NewSource, Source } from '@/modules/source/domain/source';
+
+export type SaveSource = (
+  workspaceContext: WorkspaceContext,
+  source: NewSource,
+) => Promise<Result<Source, SourceNameEnvironmentConflictError>>;
+
+export type FindSourcesByWorkspace = (workspaceContext: WorkspaceContext) => Promise<Source[]>;

--- a/src/modules/source/domain/source.ts
+++ b/src/modules/source/domain/source.ts
@@ -1,0 +1,10 @@
+export interface Source {
+  id: string;
+  description: string;
+  environment: string;
+  label: string;
+  name: string;
+  workspaceId: string;
+}
+
+export type NewSource = Omit<Source, 'id' | 'workspaceId'>;

--- a/src/modules/source/infrastructure/repository/find-sources-by-workspace.test.ts
+++ b/src/modules/source/infrastructure/repository/find-sources-by-workspace.test.ts
@@ -1,0 +1,37 @@
+import { ObjectId } from 'mongodb';
+import { describe, expect, test, vi } from 'vitest';
+import type { SourcesCollection } from '@/modules/shared/persistence/mongodb/sources-collection-schema';
+import { createFindSourcesByWorkspace } from '@/modules/source/infrastructure/repository/find-sources-by-workspace';
+
+describe('Find Sources By Workspace Repository', () => {
+  test('filters sources by workspace context', async () => {
+    const toArray = vi.fn().mockResolvedValue([
+      {
+        _id: new ObjectId('000000000000000000000001'),
+        description: 'Production customer data',
+        environment: 'production',
+        label: 'Production',
+        name: 'web',
+        workspace_id: 'workspace-123',
+      },
+    ]);
+    const find = vi.fn().mockReturnValue({ toArray });
+    const findSourcesByWorkspace = createFindSourcesByWorkspace({
+      sourcesCollection: { find } as unknown as SourcesCollection,
+    });
+
+    const result = await findSourcesByWorkspace({ workspaceId: 'workspace-123' });
+
+    expect(find).toHaveBeenCalledWith({ workspace_id: 'workspace-123' });
+    expect(result).toEqual([
+      {
+        id: '000000000000000000000001',
+        description: 'Production customer data',
+        environment: 'production',
+        label: 'Production',
+        name: 'web',
+        workspaceId: 'workspace-123',
+      },
+    ]);
+  });
+});

--- a/src/modules/source/infrastructure/repository/find-sources-by-workspace.ts
+++ b/src/modules/source/infrastructure/repository/find-sources-by-workspace.ts
@@ -1,0 +1,31 @@
+import type {
+  SourceCollectionSchema,
+  SourcesCollection,
+} from '@/modules/shared/persistence/mongodb/sources-collection-schema';
+import type { FindSourcesByWorkspace } from '@/modules/source/domain/source-repository';
+import type { Source } from '@/modules/source/domain/source';
+
+type FindSourcesByWorkspaceDependencies = Readonly<{
+  sourcesCollection: SourcesCollection;
+}>;
+
+function toSource(document: SourceCollectionSchema): Source {
+  return {
+    id: document._id.toHexString(),
+    description: document.description,
+    environment: document.environment,
+    label: document.label,
+    name: document.name,
+    workspaceId: document.workspace_id,
+  };
+}
+
+export function createFindSourcesByWorkspace({
+  sourcesCollection,
+}: FindSourcesByWorkspaceDependencies): FindSourcesByWorkspace {
+  return async ({ workspaceId }) => {
+    const sources = await sourcesCollection.find({ workspace_id: workspaceId }).toArray();
+
+    return sources.map(toSource);
+  };
+}

--- a/src/modules/source/infrastructure/repository/save-source.test.ts
+++ b/src/modules/source/infrastructure/repository/save-source.test.ts
@@ -1,0 +1,93 @@
+import { expectAsyncToThrow } from '@tests/__vitest__/expect-async-to-throw';
+import { MongoServerError, ObjectId } from 'mongodb';
+import { describe, expect, test, vi } from 'vitest';
+import type { SourcesCollection } from '@/modules/shared/persistence/mongodb/sources-collection-schema';
+import { sourceNameEnvironmentConflictError } from '@/modules/source/domain/errors';
+import { createSaveSource } from '@/modules/source/infrastructure/repository/save-source';
+
+describe('Save Source Repository', () => {
+  test('creates a source owned by the workspace context', async () => {
+    const insertedId = new ObjectId('000000000000000000000001');
+    const insertOne = vi.fn().mockResolvedValue({ insertedId });
+    const saveSource = createSaveSource({
+      sourcesCollection: { insertOne } as unknown as SourcesCollection,
+    });
+
+    const result = await saveSource(
+      { workspaceId: 'workspace-123' },
+      {
+        description: 'Production customer data',
+        environment: 'production',
+        label: 'Production',
+        name: 'web',
+      },
+    );
+
+    expect(insertOne).toHaveBeenCalledWith({
+      description: 'Production customer data',
+      environment: 'production',
+      label: 'Production',
+      name: 'web',
+      workspace_id: 'workspace-123',
+    });
+    expect(result).toEqual({
+      isOk: true,
+      value: {
+        id: insertedId.toHexString(),
+        description: 'Production customer data',
+        environment: 'production',
+        label: 'Production',
+        name: 'web',
+        workspaceId: 'workspace-123',
+      },
+    });
+  });
+
+  test('returns conflict when source name already exists in the workspace environment', async () => {
+    const insertOne = vi.fn().mockRejectedValue(
+      new MongoServerError({
+        message: 'Duplicate key',
+        code: 11000,
+      }),
+    );
+    const saveSource = createSaveSource({
+      sourcesCollection: { insertOne } as unknown as SourcesCollection,
+    });
+
+    const result = await saveSource(
+      { workspaceId: 'workspace-123' },
+      {
+        description: 'Production customer data',
+        environment: 'production',
+        label: 'Production',
+        name: 'web',
+      },
+    );
+
+    expect(result).toEqual({
+      isOk: false,
+      error: sourceNameEnvironmentConflictError,
+    });
+  });
+
+  test('throws non duplicate errors', async () => {
+    const failure = new Error('Database error');
+    const insertOne = vi.fn().mockRejectedValue(failure);
+    const saveSource = createSaveSource({
+      sourcesCollection: { insertOne } as unknown as SourcesCollection,
+    });
+
+    await expectAsyncToThrow(
+      saveSource(
+        { workspaceId: 'workspace-123' },
+        {
+          description: 'Production customer data',
+          environment: 'production',
+          label: 'Production',
+          name: 'web',
+        },
+      ),
+      failure,
+    );
+  });
+});

--- a/src/modules/source/infrastructure/repository/save-source.ts
+++ b/src/modules/source/infrastructure/repository/save-source.ts
@@ -1,0 +1,42 @@
+import { MongoServerError } from 'mongodb';
+import { err, ok } from '@/modules/shared/kernel/result';
+import type { SourcesCollection } from '@/modules/shared/persistence/mongodb/sources-collection-schema';
+import { sourceNameEnvironmentConflictError } from '@/modules/source/domain/errors';
+import type { SaveSource } from '@/modules/source/domain/source-repository';
+
+type SaveSourceDependencies = Readonly<{
+  sourcesCollection: SourcesCollection;
+}>;
+
+const DUPLICATE_KEY_ERROR_CODE = 11000;
+
+function isDuplicateError(error: unknown): boolean {
+  return error instanceof MongoServerError && error.code === DUPLICATE_KEY_ERROR_CODE;
+}
+
+export function createSaveSource({ sourcesCollection }: SaveSourceDependencies): SaveSource {
+  return async ({ workspaceId }, { description, environment, label, name }) => {
+    try {
+      const inserted = await sourcesCollection.insertOne({
+        description,
+        environment,
+        label,
+        name,
+        workspace_id: workspaceId,
+      });
+
+      return ok({
+        id: inserted.insertedId.toHexString(),
+        description,
+        environment,
+        label,
+        name,
+        workspaceId,
+      });
+    } catch (error: unknown) {
+      if (isDuplicateError(error)) return err(sourceNameEnvironmentConflictError);
+
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
| Q       | A            |
| ------- | ------------ |
| License | GPLv3        |
| Issue   | Closes #68   |

## Context

This PR builds on the workspace-context foundation from #138 by introducing the tenant-isolation boundary for sources. The idea is that source data access should be workspace-scoped by construction, not left to callers to remember filters later.

Review this as the persistence guardrail layer of the stack: the important question is whether source ownership, duplicate scope, and query boundaries make cross-workspace leakage hard to introduce.