### PR TITLE
Add source creation flow

### DIFF
--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -1,15 +1,31 @@
+import type { CreateIndexesOptions, IndexSpecification } from 'mongodb';
+import { sourcesCollectionName } from '@/framework/mongodb/schema/sources-collection-schema';
 import { workspacesCollectionName } from '@/framework/mongodb/schema/workspaces-collection-schema';
 import { assertIsNonEmptyString } from '@/kairos/shared/assert/string-assertions';
+
+type MongoIndexConfig = Readonly<{
+  collectionName: string;
+  keys: IndexSpecification;
+  options?: CreateIndexesOptions;
+}>;
 
 const connectionString = process.env.MONGODB_CONNECTION_STRING;
 assertIsNonEmptyString(connectionString, 'MONGODB_CONNECTION_STRING is not defined in environment variables');
 
-export const mongodbConfig = {
+export const mongodbConfig: Readonly<{
+  connectionString: string;
+  indexes: readonly MongoIndexConfig[];
+}> = {
   connectionString,
   indexes: [
     {
       collectionName: workspacesCollectionName,
       keys: { slug: 1 },
+      options: { unique: true },
+    },
+    {
+      collectionName: sourcesCollectionName,
+      keys: { workspace_id: 1, name: 1 },
       options: { unique: true },
     },
   ],

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,10 +1,11 @@
 import { authenticationRoutes } from '@/kairos/authentication/interface/http/authentication-routes';
+import { sourceRoutes } from '@/kairos/source/source-routes';
 import { homeRoute } from '@/kairos/system/interface/http/system-routes';
 import { workspaceRoutes } from '@/kairos/workspace/workspace-routes';
 import { RouteGroup } from '@koala-ts/framework/routing';
 
 const apiRoutes = RouteGroup({ prefix: '/api', namePrefix: 'api.' }, () => [
-  RouteGroup({ prefix: '/v1', namePrefix: 'v1.' }, () => [authenticationRoutes, workspaceRoutes]),
+  RouteGroup({ prefix: '/v1', namePrefix: 'v1.' }, () => [authenticationRoutes, workspaceRoutes, sourceRoutes]),
 ]);
 
 export const routes = [homeRoute, apiRoutes];

--- a/src/framework/mongodb/collection/sources-collection.ts
+++ b/src/framework/mongodb/collection/sources-collection.ts
@@ -1,0 +1,4 @@
+import { mongoDBClient } from '@/framework/mongodb/client/client';
+import { type SourcesCollection, sourcesCollectionName } from '@/framework/mongodb/schema/sources-collection-schema';
+
+export const sourcesCollection: SourcesCollection = mongoDBClient.db().collection(sourcesCollectionName);

--- a/src/framework/mongodb/schema/sources-collection-schema.ts
+++ b/src/framework/mongodb/schema/sources-collection-schema.ts
@@ -1,0 +1,15 @@
+import { type Collection, type ObjectId, type OptionalId } from 'mongodb';
+
+export interface SourceCollectionSchema {
+  _id: ObjectId;
+  description?: string;
+  environments: string[];
+  labels: string[];
+  name: string;
+  write_key: string;
+  workspace_id: ObjectId;
+}
+
+export type SourcesCollection = Collection<OptionalId<SourceCollectionSchema>>;
+
+export const sourcesCollectionName = 'sources';

--- a/src/kairos/source/adapter/http/create-source/create-source-controller.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-controller.ts
@@ -6,6 +6,7 @@ import { type HttpScope } from '@koala-ts/framework';
 
 export async function createSourceController({ request, response }: HttpScope): Promise<void> {
   const { body, params } = request as CreateSourceRequest;
+
   const result = await createSource({
     description: body.description,
     environments: body.environments,

--- a/src/kairos/source/adapter/http/create-source/create-source-controller.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-controller.ts
@@ -1,0 +1,21 @@
+import { mapResultToHttp } from '@/interface/http/map-result-to-http';
+import type { CreateSourceRequest } from '@/kairos/source/adapter/http/create-source/create-source-request';
+import { createSourceResponse } from '@/kairos/source/adapter/http/create-source/create-source-response';
+import { createSource } from '@/kairos/source/create-source/create-source.compose';
+import { type HttpScope } from '@koala-ts/framework';
+
+export async function createSourceController({ request, response }: HttpScope): Promise<void> {
+  const { body, params } = request as CreateSourceRequest;
+  const result = await createSource({
+    description: body.description,
+    environments: body.environments,
+    labels: body.labels,
+    name: body.name,
+    workspaceId: params.workspaceId,
+  });
+
+  const http = mapResultToHttp(result, createSourceResponse);
+
+  response.status = http.status;
+  response.body = http.body;
+}

--- a/src/kairos/source/adapter/http/create-source/create-source-request.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-request.ts
@@ -1,0 +1,19 @@
+import type { HttpRequest } from '@koala-ts/framework';
+
+export interface CreateSourceRequest extends HttpRequest {
+  body: {
+    description?: string;
+    environments: string[];
+    labels: string[];
+    name: string;
+  };
+  params: {
+    workspaceId: string;
+  };
+}
+
+export const createSourceRules = {
+  environments: ['unique', { all: { constraints: [{ type: { type: 'string' } }, 'notBlank'] } }],
+  labels: ['unique', { all: { constraints: [{ type: { type: 'string' } }, 'notBlank'] } }],
+  name: [{ type: { type: 'string' } }, 'notBlank'],
+};

--- a/src/kairos/source/adapter/http/create-source/create-source-response.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-response.ts
@@ -1,0 +1,17 @@
+import { type ResultHttpMapping } from '@/interface/http/result-to-http';
+import { HTTP_CONFLICT, HTTP_CREATED } from '@/interface/http/status-code';
+import type { CreatedSource } from '@/kairos/source/create-source/create-source';
+import type { SourceNameConflictError } from '@/kairos/source/domain/errors';
+
+export const createSourceResponse: ResultHttpMapping<CreatedSource, SourceNameConflictError> = {
+  success: {
+    status: HTTP_CREATED,
+  },
+  error: {
+    byType: {
+      SOURCE_NAME_CONFLICT: {
+        status: HTTP_CONFLICT,
+      },
+    },
+  },
+};

--- a/src/kairos/source/adapter/http/create-source/create-source-response.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-response.ts
@@ -2,6 +2,7 @@ import { type ResultHttpMapping } from '@/interface/http/result-to-http';
 import { HTTP_CONFLICT, HTTP_CREATED } from '@/interface/http/status-code';
 import type { CreatedSource } from '@/kairos/source/create-source/create-source';
 import type { SourceNameConflictError } from '@/kairos/source/domain/errors';
+import { sourceNameConflictError } from '@/kairos/source/domain/errors';
 
 export const createSourceResponse: ResultHttpMapping<CreatedSource, SourceNameConflictError> = {
   success: {
@@ -9,7 +10,7 @@ export const createSourceResponse: ResultHttpMapping<CreatedSource, SourceNameCo
   },
   error: {
     byType: {
-      SOURCE_NAME_CONFLICT: {
+      [sourceNameConflictError.type]: {
         status: HTTP_CONFLICT,
       },
     },

--- a/src/kairos/source/adapter/mongodb/find-sources-by-workspace.test.ts
+++ b/src/kairos/source/adapter/mongodb/find-sources-by-workspace.test.ts
@@ -1,0 +1,46 @@
+import { sourcesCollection } from '@/framework/mongodb/collection/sources-collection';
+import { findSourcesByWorkspaceInMongoDB } from '@/kairos/source/adapter/mongodb/find-sources-by-workspace';
+import { integrationTest } from '@tests/__vitest__/integration-test';
+import { ObjectId } from 'mongodb';
+import { describe, expect, test } from 'vitest';
+
+describe('Find sources by workspace in MongoDB', () => {
+  integrationTest();
+
+  test('filters sources by workspace context', async () => {
+    const workspaceId = new ObjectId();
+    const otherWorkspaceId = new ObjectId();
+    await sourcesCollection.insertMany([
+      {
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        write_key: 'write-key-123',
+        workspace_id: workspaceId,
+      },
+      {
+        description: 'Mobile customer data',
+        environments: ['production'],
+        labels: ['customer-data', 'mobile'],
+        name: 'mobile',
+        write_key: 'write-key-456',
+        workspace_id: otherWorkspaceId,
+      },
+    ]);
+    const findSourcesByWorkspace = findSourcesByWorkspaceInMongoDB(sourcesCollection);
+
+    const result = await findSourcesByWorkspace(workspaceId.toHexString());
+
+    expect(result).toEqual([
+      {
+        id: expect.any(String),
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        workspaceId: workspaceId.toHexString(),
+      },
+    ]);
+  });
+});

--- a/src/kairos/source/adapter/mongodb/find-sources-by-workspace.ts
+++ b/src/kairos/source/adapter/mongodb/find-sources-by-workspace.ts
@@ -1,0 +1,24 @@
+import type {
+  SourceCollectionSchema,
+  SourcesCollection,
+} from '@/framework/mongodb/schema/sources-collection-schema';
+import type { FindSourcesByWorkspace } from '@/kairos/source/find-sources-by-workspace/find-sources-by-workspace.type';
+import type { Source } from '@/kairos/source/domain/source';
+import { ObjectId } from 'mongodb';
+
+const toSource = (document: SourceCollectionSchema): Source => ({
+  id: document._id.toHexString(),
+  description: document.description,
+  environments: document.environments,
+  labels: document.labels,
+  name: document.name,
+  workspaceId: document.workspace_id.toHexString(),
+});
+
+export const findSourcesByWorkspaceInMongoDB =
+  (collection: SourcesCollection): FindSourcesByWorkspace =>
+  async workspaceId => {
+    const sources = await collection.find({ workspace_id: new ObjectId(workspaceId) }).toArray();
+
+    return sources.map(toSource);
+  };

--- a/src/kairos/source/adapter/mongodb/find-sources-by-workspace.ts
+++ b/src/kairos/source/adapter/mongodb/find-sources-by-workspace.ts
@@ -1,7 +1,4 @@
-import type {
-  SourceCollectionSchema,
-  SourcesCollection,
-} from '@/framework/mongodb/schema/sources-collection-schema';
+import type { SourceCollectionSchema, SourcesCollection } from '@/framework/mongodb/schema/sources-collection-schema';
 import type { FindSourcesByWorkspace } from '@/kairos/source/find-sources-by-workspace/find-sources-by-workspace.type';
 import type { Source } from '@/kairos/source/domain/source';
 import { ObjectId } from 'mongodb';

--- a/src/kairos/source/adapter/mongodb/insert-source.test.ts
+++ b/src/kairos/source/adapter/mongodb/insert-source.test.ts
@@ -1,0 +1,93 @@
+import { sourcesCollection } from '@/framework/mongodb/collection/sources-collection';
+import type { SourcesCollection } from '@/framework/mongodb/schema/sources-collection-schema';
+import { insertSourceIntoMongoDB } from '@/kairos/source/adapter/mongodb/insert-source';
+import { sourceNameConflictError } from '@/kairos/source/domain/errors';
+import { expectAsyncToThrow } from '@tests/__vitest__/expect-async-to-throw';
+import { integrationTest } from '@tests/__vitest__/integration-test';
+import { ObjectId } from 'mongodb';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('Insert source into MongoDB', () => {
+  integrationTest();
+
+  test('creates a source owned by the workspace context', async () => {
+    const insertSource = insertSourceIntoMongoDB(sourcesCollection);
+    const workspaceId = new ObjectId().toHexString();
+
+    const result = await insertSource({
+      description: 'Production customer data',
+      environments: ['production', 'staging'],
+      labels: ['customer-data', 'web'],
+      name: 'web',
+      workspaceId,
+      writeKey: 'write-key-123',
+    });
+
+    const persistedSource = await sourcesCollection.findOne({ workspace_id: new ObjectId(workspaceId), name: 'web' });
+    expect(result).toEqual({
+      isOk: true,
+      value: {
+        id: expect.any(String),
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        workspaceId,
+      },
+    });
+    expect(persistedSource).toEqual(
+      expect.objectContaining({
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        write_key: 'write-key-123',
+        workspace_id: new ObjectId(workspaceId),
+      }),
+    );
+  });
+
+  test('returns conflict when source name already exists in the workspace', async () => {
+    const insertSource = insertSourceIntoMongoDB(sourcesCollection);
+    const workspaceId = new ObjectId().toHexString();
+    await insertSource({
+      environments: ['production'],
+      labels: ['customer-data'],
+      name: 'web',
+      workspaceId,
+      writeKey: 'write-key-123',
+    });
+
+    const result = await insertSource({
+      environments: ['production', 'staging'],
+      labels: ['customer-data', 'web'],
+      name: 'web',
+      workspaceId,
+      writeKey: 'write-key-456',
+    });
+
+    expect(result).toEqual({
+      isOk: false,
+      error: sourceNameConflictError,
+    });
+  });
+
+  test('throws non duplicate errors', async () => {
+    const failure = new Error('Database error');
+    const workspaceId = new ObjectId().toHexString();
+    const insertOne = vi.fn().mockRejectedValue(failure);
+    const insertSource = insertSourceIntoMongoDB({ insertOne } as unknown as SourcesCollection);
+
+    await expectAsyncToThrow(
+      insertSource({
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        workspaceId,
+        writeKey: 'write-key-123',
+      }),
+      failure,
+    );
+  });
+});

--- a/src/kairos/source/adapter/mongodb/insert-source.ts
+++ b/src/kairos/source/adapter/mongodb/insert-source.ts
@@ -1,0 +1,35 @@
+import { ObjectId } from 'mongodb';
+import { isDuplicateError } from '@/framework/mongodb/error/is-duplicate-error';
+import type { SourcesCollection } from '@/framework/mongodb/schema/sources-collection-schema';
+import { err } from '@/kairos/shared/result/err';
+import { ok } from '@/kairos/shared/result/ok';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import { sourceNameConflictError } from '@/kairos/source/domain/errors';
+
+export const insertSourceIntoMongoDB =
+  (collection: SourcesCollection): InsertSource =>
+  async ({ description, environments, labels, name, workspaceId, writeKey }) => {
+    try {
+      const inserted = await collection.insertOne({
+        description,
+        environments,
+        labels,
+        name,
+        write_key: writeKey,
+        workspace_id: new ObjectId(workspaceId),
+      });
+
+      return ok({
+        id: inserted.insertedId.toHexString(),
+        description,
+        environments,
+        labels,
+        name,
+        workspaceId,
+      });
+    } catch (error: unknown) {
+      if (isDuplicateError(error)) return err(sourceNameConflictError);
+
+      throw error;
+    }
+  };

--- a/src/kairos/source/adapter/security/generate-write-key.test.ts
+++ b/src/kairos/source/adapter/security/generate-write-key.test.ts
@@ -1,0 +1,10 @@
+import { generateWriteKey } from '@/kairos/source/adapter/security/generate-write-key';
+import { describe, expect, test } from 'vitest';
+
+describe('Generate write key', () => {
+  test('generates a write key', () => {
+    const writeKey = generateWriteKey();
+
+    expect(writeKey).toMatch(/^kairos_wk_[a-f0-9]{64}$/);
+  });
+});

--- a/src/kairos/source/adapter/security/generate-write-key.ts
+++ b/src/kairos/source/adapter/security/generate-write-key.ts
@@ -1,0 +1,5 @@
+import { randomBytes } from 'node:crypto';
+
+export function generateWriteKey(): string {
+  return `kairos_wk_${randomBytes(32).toString('hex')}`;
+}

--- a/src/kairos/source/create-source/create-source-command.type.ts
+++ b/src/kairos/source/create-source/create-source-command.type.ts
@@ -1,0 +1,7 @@
+export type CreateSourceCommand = Readonly<{
+  description?: string;
+  environments: string[];
+  labels: string[];
+  name: string;
+  workspaceId: string;
+}>;

--- a/src/kairos/source/create-source/create-source.compose.ts
+++ b/src/kairos/source/create-source/create-source.compose.ts
@@ -1,0 +1,9 @@
+import { sourcesCollection } from '@/framework/mongodb/collection/sources-collection';
+import { insertSourceIntoMongoDB } from '@/kairos/source/adapter/mongodb/insert-source';
+import { generateWriteKey } from '@/kairos/source/adapter/security/generate-write-key';
+import { makeCreateSource } from '@/kairos/source/create-source/create-source';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+
+const insertSource: InsertSource = insertSourceIntoMongoDB(sourcesCollection);
+
+export const createSource = makeCreateSource({ generateWriteKey, insertSource });

--- a/src/kairos/source/create-source/create-source.test.ts
+++ b/src/kairos/source/create-source/create-source.test.ts
@@ -1,0 +1,52 @@
+import { ok } from '@/kairos/shared/result/ok';
+import { makeCreateSource } from '@/kairos/source/create-source/create-source';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('Create source', () => {
+  test('requires workspace context and generates a one-time write key', async () => {
+    const insertSource: InsertSource = vi.fn().mockResolvedValue(
+      ok({
+        id: 'source-123',
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        workspaceId: 'workspace-123',
+      }),
+    );
+    const createSource = makeCreateSource({
+      generateWriteKey: () => 'write-key-123',
+      insertSource,
+    });
+
+    const result = await createSource({
+      description: 'Production customer data',
+      environments: ['production', 'staging'],
+      labels: ['customer-data', 'web'],
+      name: 'web',
+      workspaceId: 'workspace-123',
+    });
+
+    expect(insertSource).toHaveBeenCalledWith({
+      description: 'Production customer data',
+      environments: ['production', 'staging'],
+      labels: ['customer-data', 'web'],
+      name: 'web',
+      workspaceId: 'workspace-123',
+      writeKey: 'write-key-123',
+    });
+    expect(result).toEqual({
+      isOk: true,
+      value: {
+        id: 'source-123',
+        description: 'Production customer data',
+        environments: ['production', 'staging'],
+        labels: ['customer-data', 'web'],
+        name: 'web',
+        workspaceId: 'workspace-123',
+        write_key: 'write-key-123',
+      },
+    });
+  });
+});

--- a/src/kairos/source/create-source/create-source.ts
+++ b/src/kairos/source/create-source/create-source.ts
@@ -1,0 +1,36 @@
+import type { Result } from '@/kairos/shared/result/result.type';
+import type { CreateSourceCommand } from '@/kairos/source/create-source/create-source-command.type';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import type { SourceNameConflictError } from '@/kairos/source/domain/errors';
+import type { Source } from '@/kairos/source/domain/source';
+import { initializeSource } from '@/kairos/source/domain/source';
+
+type GenerateWriteKey = () => string;
+
+export type CreatedSource = Source & {
+  write_key: string;
+};
+
+export type CreateSourceResult = Result<CreatedSource, SourceNameConflictError>;
+
+export const makeCreateSource =
+  (dependencies: Readonly<{ generateWriteKey: GenerateWriteKey; insertSource: InsertSource }>) =>
+  async (command: CreateSourceCommand): Promise<CreateSourceResult> => {
+    const writeKey = dependencies.generateWriteKey();
+    const result = await dependencies.insertSource(
+      initializeSource({
+        ...command,
+        writeKey,
+      }),
+    );
+
+    if (!result.isOk) return result;
+
+    return {
+      isOk: true,
+      value: {
+        ...result.value,
+        write_key: writeKey,
+      },
+    };
+  };

--- a/src/kairos/source/create-source/insert-source.type.ts
+++ b/src/kairos/source/create-source/insert-source.type.ts
@@ -1,0 +1,7 @@
+import type { Result } from '@/kairos/shared/result/result.type';
+import type { SourceNameConflictError } from '@/kairos/source/domain/errors';
+import type { InitialSource, Source } from '@/kairos/source/domain/source';
+
+type InsertSourceResult = Result<Source, SourceNameConflictError>;
+
+export type InsertSource = (source: InitialSource) => Promise<InsertSourceResult>;

--- a/src/kairos/source/domain/errors.ts
+++ b/src/kairos/source/domain/errors.ts
@@ -1,0 +1,6 @@
+export const sourceNameConflictError = {
+  type: 'SOURCE_NAME_CONFLICT',
+  message: 'Source name already exists in this workspace',
+} as const;
+
+export type SourceNameConflictError = typeof sourceNameConflictError;

--- a/src/kairos/source/domain/source.ts
+++ b/src/kairos/source/domain/source.ts
@@ -1,0 +1,35 @@
+export interface Source {
+  id: string;
+  description?: string;
+  environments: string[];
+  labels: string[];
+  name: string;
+  workspaceId: string;
+}
+
+export type InitializeSourceProps = Readonly<{
+  description?: string;
+  environments: string[];
+  labels: string[];
+  name: string;
+  workspaceId: string;
+  writeKey: string;
+}>;
+
+export type InitialSource = Readonly<{
+  description?: string;
+  environments: string[];
+  labels: string[];
+  name: string;
+  workspaceId: string;
+  writeKey: string;
+}>;
+
+export const initializeSource = (props: InitializeSourceProps): InitialSource => ({
+  description: props.description,
+  environments: [...props.environments],
+  labels: [...props.labels],
+  name: props.name,
+  workspaceId: props.workspaceId,
+  writeKey: props.writeKey,
+});

--- a/src/kairos/source/find-sources-by-workspace/find-sources-by-workspace.type.ts
+++ b/src/kairos/source/find-sources-by-workspace/find-sources-by-workspace.type.ts
@@ -1,0 +1,3 @@
+import type { Source } from '@/kairos/source/domain/source';
+
+export type FindSourcesByWorkspace = (workspaceId: string) => Promise<Source[]>;

--- a/src/kairos/source/source-routes.ts
+++ b/src/kairos/source/source-routes.ts
@@ -1,0 +1,8 @@
+import { validateRequest } from '@/framework/http/validator';
+import { createSourceController } from '@/kairos/source/adapter/http/create-source/create-source-controller';
+import { createSourceRules } from '@/kairos/source/adapter/http/create-source/create-source-request';
+import { Post, RouteGroup } from '@koala-ts/framework/routing';
+
+export const sourceRoutes = RouteGroup({ prefix: '/workspaces/:workspaceId/sources', namePrefix: 'sources.' }, () => [
+  Post('/', 'create', validateRequest(createSourceRules), createSourceController),
+]);

--- a/src/kairos/workspace/adapter/http/create-workspace/create-workspace-response.ts
+++ b/src/kairos/workspace/adapter/http/create-workspace/create-workspace-response.ts
@@ -1,6 +1,7 @@
 import { type ResultHttpMapping } from '@/interface/http/result-to-http';
 import { HTTP_CONFLICT, HTTP_CREATED } from '@/interface/http/status-code';
 import type { WorkspaceSlugConflictError } from '@/kairos/workspace/domain/errors';
+import { workspaceSlugConflictError } from '@/kairos/workspace/domain/errors';
 import type { Workspace } from '@/kairos/workspace/domain/workspace';
 
 export const createWorkspaceResponse: ResultHttpMapping<Workspace, WorkspaceSlugConflictError> = {
@@ -9,7 +10,7 @@ export const createWorkspaceResponse: ResultHttpMapping<Workspace, WorkspaceSlug
   },
   error: {
     byType: {
-      WORKSPACE_SLUG_CONFLICT: {
+      [workspaceSlugConflictError.type]: {
         status: HTTP_CONFLICT,
       },
     },


### PR DESCRIPTION
| Q       | A            |
| ------- | ------------ |
| License | GPLv3        |
| Issue   | Closes #72   |

## Context

This PR implements the Kairos backend flow for creating a source as a workspace-owned resource. The workspace is represented directly in the URL, so reviewers can evaluate ownership from the route shape: a source is created under a specific workspace, not by trusting workspace ownership from the request body or from a separate temporary context abstraction.

The review focus is the tenant boundary and creation behavior: the route should make the workspace relationship explicit, source persistence should remain scoped by workspace, duplicate detection should stay scoped to workspace/name/environment, and the one-time write key should be exposed only in the creation response.