### PR TITLE
feat(source): allow user to create source

### DIFF
--- a/docs/living-domain-model.md
+++ b/docs/living-domain-model.md
@@ -1,0 +1,94 @@
+# Living Domain Model
+
+This document describes the current or the implemented domain model for the application. It is a living document that
+gets updated as the application evolves. It doesn't represent the future or the ideal state of the domain model, but
+rather the current state of the implementation.
+
+## Component Diagram
+
+```mermaid
+flowchart TB
+    Admin["Workspace Admin / Super Admin"]:::persona
+    MongoDB[("MongoDB")]:::container
+
+    subgraph KairosAPI["Kairos API Container"]
+        Authentication["Authentication Component"]:::component
+        Workspace["Workspace Component"]:::component
+        Source["Source Component"]:::component
+        Setup["Setup Component"]:::component
+    end
+
+    Admin --> Authentication
+    Admin --> Workspace
+    Admin --> Source
+    Authentication --> MongoDB
+    Workspace --> MongoDB
+    Source --> MongoDB
+    Setup --> MongoDB
+    classDef persona fill: #fef9c3, stroke: #ca8a04, color: #111827
+    classDef component fill: #fce7f3, stroke: #be185d, color: #111827
+    classDef container fill: #e5e7eb, stroke: #4b5563, color: #111827
+```
+
+## Event Storming
+
+Legend:
+
+| Color                      | Meaning               |
+|----------------------------|-----------------------|
+| Orange                     | Domain events         |
+| Light blue                 | Commands              |
+| Yellow                     | Aggregates            |
+| Red / purple               | Issues                |
+| Yellow with stick figure   | User roles / personas |
+| Green                      | Views                 |
+| Pink notes with solid line | Bounded contexts      |
+| Dashed lines               | Subdomains            |
+| Arrows                     | Event flow            |
+| Purple                     | Policies              |
+
+```mermaid
+flowchart LR
+    Admin["Workspace Admin / Super Admin"]:::persona
+
+    subgraph AuthenticationContext["Authentication"]
+        LoginCommand["Command: Login"]:::command
+        CredentialsChecked["Policy: Verify credentials"]:::policy
+        AuthenticatedUser["Aggregate: Authenticated User"]:::aggregate
+        LoginError["Issue: Invalid credentials"]:::issue
+    end
+
+    subgraph WorkspaceContext["Workspace"]
+        CreateWorkspaceCommand["Command: Create workspace"]:::command
+        WorkspaceDefaults["Policy: Apply workspace defaults"]:::policy
+        WorkspaceAggregate["Aggregate: Workspace"]:::aggregate
+        WorkspaceConflict["Issue: Workspace slug conflict"]:::issue
+    end
+
+    subgraph SourceContext["Source"]
+        CreateSourceCommand["Command: Create source"]:::command
+        SourceCredentials["Policy: Issue source write credentials"]:::policy
+        SourceDefaults["Policy: Apply source defaults"]:::policy
+        SourceAggregate["Aggregate: Source"]:::aggregate
+        SourceConflict["Issue: Source app identifier conflict in workspace"]:::issue
+    end
+
+    Admin --> LoginCommand
+    LoginCommand --> CredentialsChecked
+    CredentialsChecked --> AuthenticatedUser
+    CredentialsChecked --> LoginError
+    Admin --> CreateWorkspaceCommand
+    CreateWorkspaceCommand --> WorkspaceDefaults
+    WorkspaceDefaults --> WorkspaceAggregate
+    WorkspaceDefaults --> WorkspaceConflict
+    Admin --> CreateSourceCommand
+    CreateSourceCommand --> SourceCredentials
+    SourceCredentials --> SourceDefaults
+    SourceDefaults --> SourceAggregate
+    SourceDefaults --> SourceConflict
+    classDef persona fill: #fef9c3, stroke: #ca8a04, color: #111827
+    classDef command fill: #dbeafe, stroke: #2563eb, color: #111827
+    classDef aggregate fill: #fef3c7, stroke: #d97706, color: #111827
+    classDef issue fill: #fee2e2, stroke: #dc2626, color: #111827
+    classDef policy fill: #f3e8ff, stroke: #9333ea, color: #111827
+```

--- a/docs/living-domain-model.md
+++ b/docs/living-domain-model.md
@@ -35,7 +35,7 @@ flowchart TB
 Legend:
 
 | Color                      | Meaning               |
-|----------------------------|-----------------------|
+| -------------------------- | --------------------- |
 | Orange                     | Domain events         |
 | Light blue                 | Commands              |
 | Yellow                     | Aggregates            |

--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -1,16 +1,25 @@
+import type { MongoIndexConfig } from '@/framework/mongodb/index/create-ensure-indexes';
+import { sourcesCollectionName } from '@/framework/mongodb/schema/sources-collection-schema';
 import { workspacesCollectionName } from '@/framework/mongodb/schema/workspaces-collection-schema';
 import { assertIsNonEmptyString } from '@/kairos/shared/assert/string-assertions';
 
 const connectionString = process.env.MONGODB_CONNECTION_STRING;
 assertIsNonEmptyString(connectionString, 'MONGODB_CONNECTION_STRING is not defined in environment variables');
 
+const indexes: readonly MongoIndexConfig[] = [
+  {
+    collectionName: workspacesCollectionName,
+    keys: { slug: 1 },
+    options: { unique: true },
+  },
+  {
+    collectionName: sourcesCollectionName,
+    keys: { workspace_id: 1, app_identifier: 1 },
+    options: { unique: true },
+  },
+];
+
 export const mongodbConfig = {
   connectionString,
-  indexes: [
-    {
-      collectionName: workspacesCollectionName,
-      keys: { slug: 1 },
-      options: { unique: true },
-    },
-  ],
+  indexes,
 };

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,10 +1,11 @@
 import { authenticationRoutes } from '@/kairos/authentication/interface/http/authentication-routes';
+import { sourceRoutes } from '@/kairos/source/source-routes';
 import { homeRoute } from '@/kairos/system/interface/http/system-routes';
 import { workspaceRoutes } from '@/kairos/workspace/workspace-routes';
 import { RouteGroup } from '@koala-ts/framework/routing';
 
 const apiRoutes = RouteGroup({ prefix: '/api', namePrefix: 'api.' }, () => [
-  RouteGroup({ prefix: '/v1', namePrefix: 'v1.' }, () => [authenticationRoutes, workspaceRoutes]),
+  RouteGroup({ prefix: '/v1', namePrefix: 'v1.' }, () => [authenticationRoutes, workspaceRoutes, sourceRoutes]),
 ]);
 
 export const routes = [homeRoute, apiRoutes];

--- a/src/framework/mongodb/collection/sources-collection.ts
+++ b/src/framework/mongodb/collection/sources-collection.ts
@@ -1,0 +1,5 @@
+import { mongoDBClient } from '@/framework/mongodb/client/client';
+import type { SourcesCollection } from '@/framework/mongodb/schema/sources-collection-schema';
+import { sourcesCollectionName } from '@/framework/mongodb/schema/sources-collection-schema';
+
+export const sourcesCollection: SourcesCollection = mongoDBClient.db().collection(sourcesCollectionName);

--- a/src/framework/mongodb/index/create-ensure-indexes.ts
+++ b/src/framework/mongodb/index/create-ensure-indexes.ts
@@ -1,6 +1,6 @@
 import type { CreateIndexesOptions, Db, IndexSpecification } from 'mongodb';
 
-type MongoIndexConfig = Readonly<{
+export type MongoIndexConfig = Readonly<{
   collectionName: string;
   keys: IndexSpecification;
   options?: CreateIndexesOptions;

--- a/src/framework/mongodb/schema/sources-collection-schema.ts
+++ b/src/framework/mongodb/schema/sources-collection-schema.ts
@@ -1,0 +1,14 @@
+import type { Collection, ObjectId, OptionalId } from 'mongodb';
+
+export interface SourceCollectionSchema {
+  _id: ObjectId;
+  workspace_id: ObjectId;
+  name: string;
+  description: string | null;
+  app_identifier: string;
+  write_key_hash: string;
+}
+
+export type SourcesCollection = Collection<OptionalId<SourceCollectionSchema>>;
+
+export const sourcesCollectionName = 'sources';

--- a/src/framework/security/password.ts
+++ b/src/framework/security/password.ts
@@ -1,3 +1,5 @@
 import { createPasswordHasher } from '@koala-ts/framework';
 
 export const passwordHasher = createPasswordHasher();
+
+export const hashPassword = (plainPassword: string): Promise<string> => passwordHasher.hash(plainPassword);

--- a/src/kairos/authentication/authentication-composition.ts
+++ b/src/kairos/authentication/authentication-composition.ts
@@ -10,7 +10,7 @@ import {
   createJwtAccessTokenSigner,
   type SignAccessToken,
 } from '@/kairos/authentication/infrastructure/security/access-token';
-import { passwordHasher } from '@/kairos/authentication/infrastructure/security/password/password-hasher';
+import { passwordHasher } from '@/framework/security/password';
 import { createVerifyPassword } from '@/kairos/authentication/infrastructure/security/password/verify-password';
 import { loginRequestConstraints } from '@/kairos/authentication/interface/http/login-request';
 import { systemClock } from '@/kairos/shared/clock/clock';

--- a/src/kairos/authentication/infrastructure/security/password/hash-password.ts
+++ b/src/kairos/authentication/infrastructure/security/password/hash-password.ts
@@ -1,3 +1,0 @@
-import { passwordHasher } from '@/kairos/authentication/infrastructure/security/password/password-hasher';
-
-export const hashPassword = (plainPassword: string): Promise<string> => passwordHasher.hash(plainPassword);

--- a/src/kairos/authentication/infrastructure/security/password/verify-password.test.ts
+++ b/src/kairos/authentication/infrastructure/security/password/verify-password.test.ts
@@ -1,5 +1,5 @@
 import { invalidCredentialsError } from '@/kairos/authentication/domain/errors';
-import { passwordHasher } from '@/kairos/authentication/infrastructure/security/password/password-hasher';
+import { passwordHasher } from '@/framework/security/password';
 import { describe, expect, it } from 'vitest';
 import { createVerifyPassword } from './verify-password';
 

--- a/src/kairos/setup/setup-composition.ts
+++ b/src/kairos/setup/setup-composition.ts
@@ -1,6 +1,6 @@
 import { mongodbConfig } from '@/config/mongodb';
 import { setupConfig } from '@/config/setup';
-import { hashPassword } from '@/kairos/authentication/infrastructure/security/password/hash-password';
+import { hashPassword } from '@/framework/security/password';
 import { createEnsureSuperAdminTask } from '@/kairos/setup/application/ensure-super-admin';
 import { runSetup, type SetupTask } from '@/kairos/setup/application/run-setup';
 import type { CreateSuperAdmin, ExistsSuperAdmin } from '@/kairos/setup/domain/super-admin-repository';

--- a/src/kairos/source/adapter/http/create-source/create-source-controller.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-controller.ts
@@ -1,0 +1,22 @@
+import { mapResultToHttp } from '@/interface/http/map-result-to-http';
+import type { CreateSourceRequest } from '@/kairos/source/adapter/http/create-source/create-source-request';
+import { createSourceResponse } from '@/kairos/source/adapter/http/create-source/create-source-response';
+import { createSource } from '@/kairos/source/create-source/create-source.compose';
+import type { HttpScope } from '@koala-ts/framework';
+
+export async function createSourceController({ request, response }: HttpScope): Promise<void> {
+  const params = request.params as CreateSourceRequest['params'];
+  const body = request.body as CreateSourceRequest['body'];
+
+  const result = await createSource({
+    workspaceId: params.workspaceId,
+    name: body.name,
+    description: body.description,
+    appIdentifier: body.appIdentifier,
+  });
+
+  const http = mapResultToHttp(result, createSourceResponse);
+
+  response.status = http.status;
+  response.body = http.body;
+}

--- a/src/kairos/source/adapter/http/create-source/create-source-request.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-request.ts
@@ -1,0 +1,18 @@
+import type { HttpRequest } from '@koala-ts/framework';
+
+export interface CreateSourceRequest extends HttpRequest {
+  params: {
+    workspaceId: string;
+  };
+  body: {
+    name: string;
+    description?: string;
+    appIdentifier: string;
+  };
+}
+
+export const createSourceRules = {
+  name: ['notBlank', { type: { type: 'string' } }],
+  description: [{ type: { type: 'string' } }],
+  appIdentifier: ['notBlank', { type: { type: 'string' } }],
+};

--- a/src/kairos/source/adapter/http/create-source/create-source-response.ts
+++ b/src/kairos/source/adapter/http/create-source/create-source-response.ts
@@ -1,0 +1,18 @@
+import type { ResultHttpMapping } from '@/interface/http/result-to-http';
+import { HTTP_CONFLICT, HTTP_CREATED } from '@/interface/http/status-code';
+import type { CreatedSource } from '@/kairos/source/create-source/create-source';
+import type { SourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+import { sourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+
+export const createSourceResponse: ResultHttpMapping<CreatedSource, SourceAppIdentifierConflictError> = {
+  success: {
+    status: HTTP_CREATED,
+  },
+  error: {
+    byType: {
+      [sourceAppIdentifierConflictError.type]: {
+        status: HTTP_CONFLICT,
+      },
+    },
+  },
+};

--- a/src/kairos/source/adapter/mongodb/insert-source.ts
+++ b/src/kairos/source/adapter/mongodb/insert-source.ts
@@ -1,0 +1,35 @@
+import { isDuplicateError } from '@/framework/mongodb/error/is-duplicate-error';
+import type { SourcesCollection } from '@/framework/mongodb/schema/sources-collection-schema';
+import { err } from '@/kairos/shared/result/err';
+import { ok } from '@/kairos/shared/result/ok';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import { sourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+import { ObjectId } from 'mongodb';
+
+export const makeInsertSource =
+  (collection: SourcesCollection): InsertSource =>
+  async ({ workspaceId, name, description, appIdentifier, writeKeyHash }) => {
+    try {
+      const document = {
+        workspace_id: new ObjectId(workspaceId),
+        name,
+        app_identifier: appIdentifier,
+        write_key_hash: writeKeyHash,
+        description,
+      };
+      const inserted = await collection.insertOne(document);
+
+      return ok({
+        id: inserted.insertedId.toHexString(),
+        workspaceId,
+        name,
+        description,
+        appIdentifier,
+        writeKeyHash,
+      });
+    } catch (error: unknown) {
+      if (isDuplicateError(error)) return err(sourceAppIdentifierConflictError);
+
+      throw error;
+    }
+  };

--- a/src/kairos/source/adapter/write-key/generate-write-key.test.ts
+++ b/src/kairos/source/adapter/write-key/generate-write-key.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest';
+import { generateWriteKey } from './generate-write-key';
+
+describe('generate write key', () => {
+  test('returns url-safe random write keys', () => {
+    const firstWriteKey = generateWriteKey();
+    const secondWriteKey = generateWriteKey();
+
+    expect(firstWriteKey).toEqual(expect.any(String));
+    expect(firstWriteKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secondWriteKey).toEqual(expect.any(String));
+    expect(secondWriteKey).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(secondWriteKey).not.toBe(firstWriteKey);
+  });
+});

--- a/src/kairos/source/adapter/write-key/generate-write-key.ts
+++ b/src/kairos/source/adapter/write-key/generate-write-key.ts
@@ -1,0 +1,3 @@
+import { randomBytes } from 'node:crypto';
+
+export const generateWriteKey = (): string => randomBytes(32).toString('base64url');

--- a/src/kairos/source/create-source/create-source-command.test.ts
+++ b/src/kairos/source/create-source/create-source-command.test.ts
@@ -1,0 +1,43 @@
+import { toInitializeSourceProps } from '@/kairos/source/create-source/create-source-command';
+import { describe, expect, test } from 'vitest';
+
+describe('Create source command', () => {
+  test('converts command and write key hash to initialize source props', () => {
+    const props = toInitializeSourceProps(
+      {
+        workspaceId: 'workspace-id',
+        name: 'Acme iOS',
+        description: 'iOS app',
+        appIdentifier: 'com.acme.ios',
+      },
+      'write-key-hash',
+    );
+
+    expect(props).toEqual({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: 'iOS app',
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+  });
+
+  test('keeps missing description undefined for domain initialization', () => {
+    const props = toInitializeSourceProps(
+      {
+        workspaceId: 'workspace-id',
+        name: 'Acme iOS',
+        appIdentifier: 'com.acme.ios',
+      },
+      'write-key-hash',
+    );
+
+    expect(props).toEqual({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: undefined,
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+  });
+});

--- a/src/kairos/source/create-source/create-source-command.ts
+++ b/src/kairos/source/create-source/create-source-command.ts
@@ -1,0 +1,16 @@
+import type { InitializeSourceProps } from '@/kairos/source/domain/initialize-source';
+
+export type CreateSourceCommand = Readonly<{
+  workspaceId: string;
+  name: string;
+  description?: string;
+  appIdentifier: string;
+}>;
+
+export const toInitializeSourceProps = (command: CreateSourceCommand, writeKeyHash: string): InitializeSourceProps => ({
+  workspaceId: command.workspaceId,
+  name: command.name,
+  description: command.description,
+  appIdentifier: command.appIdentifier,
+  writeKeyHash,
+});

--- a/src/kairos/source/create-source/create-source.compose.ts
+++ b/src/kairos/source/create-source/create-source.compose.ts
@@ -1,0 +1,14 @@
+import { hashPassword } from '@/framework/security/password';
+import { sourcesCollection } from '@/framework/mongodb/collection/sources-collection';
+import { makeInsertSource } from '@/kairos/source/adapter/mongodb/insert-source';
+import { generateWriteKey } from '@/kairos/source/adapter/write-key/generate-write-key';
+import { makeCreateSource } from '@/kairos/source/create-source/create-source';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+
+const insertSource: InsertSource = makeInsertSource(sourcesCollection);
+
+export const createSource = makeCreateSource({
+  insertSource,
+  generateWriteKey,
+  hashWriteKey: hashPassword,
+});

--- a/src/kairos/source/create-source/create-source.test.ts
+++ b/src/kairos/source/create-source/create-source.test.ts
@@ -1,0 +1,67 @@
+import { err } from '@/kairos/shared/result/err';
+import { ok } from '@/kairos/shared/result/ok';
+import { makeCreateSource } from '@/kairos/source/create-source/create-source';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import { sourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+import { describe, expect, test, vi } from 'vitest';
+
+describe('Create source use case', () => {
+  test('creates source with null description when description is missing', async () => {
+    const insertSource: InsertSource = vi.fn().mockResolvedValue(
+      ok({
+        id: 'source-id',
+        workspaceId: 'workspace-id',
+        name: 'Acme iOS',
+        description: null,
+        appIdentifier: 'com.acme.ios',
+        writeKeyHash: 'write-key-hash',
+      }),
+    );
+    const execute = makeCreateSource({
+      insertSource,
+      generateWriteKey: () => 'write-key',
+      hashWriteKey: vi.fn().mockResolvedValue('write-key-hash'),
+    });
+
+    const result = await execute({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      appIdentifier: 'com.acme.ios',
+    });
+
+    expect(insertSource).toHaveBeenCalledWith({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: null,
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+    expect(result).toEqual(
+      ok({
+        id: 'source-id',
+        workspaceId: 'workspace-id',
+        name: 'Acme iOS',
+        description: null,
+        appIdentifier: 'com.acme.ios',
+        writeKey: 'write-key',
+      }),
+    );
+  });
+
+  test('returns conflict when app identifier already exists in workspace', async () => {
+    const insertSource: InsertSource = vi.fn().mockResolvedValue(err(sourceAppIdentifierConflictError));
+    const execute = makeCreateSource({
+      insertSource,
+      generateWriteKey: () => 'write-key',
+      hashWriteKey: vi.fn().mockResolvedValue('write-key-hash'),
+    });
+
+    const result = await execute({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      appIdentifier: 'com.acme.ios',
+    });
+
+    expect(result).toEqual(err(sourceAppIdentifierConflictError));
+  });
+});

--- a/src/kairos/source/create-source/create-source.ts
+++ b/src/kairos/source/create-source/create-source.ts
@@ -1,0 +1,51 @@
+import { isErr } from '@/kairos/shared/result/err';
+import { ok } from '@/kairos/shared/result/ok';
+import type { Result } from '@/kairos/shared/result/result.type';
+import { type CreateSourceCommand, toInitializeSourceProps } from '@/kairos/source/create-source/create-source-command';
+import type { InsertSource } from '@/kairos/source/create-source/insert-source.type';
+import type { SourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+import { initializeSource } from '@/kairos/source/domain/initialize-source';
+
+export type CreatedSource = Readonly<{
+  id: string;
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  appIdentifier: string;
+  writeKey: string;
+}>;
+
+export type CreateSourceResult = Result<CreatedSource, SourceAppIdentifierConflictError>;
+
+type GenerateWriteKey = () => string;
+
+type HashWriteKey = (writeKey: string) => Promise<string>;
+
+type CreateSourceDependencies = Readonly<{
+  insertSource: InsertSource;
+  generateWriteKey: GenerateWriteKey;
+  hashWriteKey: HashWriteKey;
+}>;
+
+export const makeCreateSource =
+  ({ insertSource, generateWriteKey, hashWriteKey }: CreateSourceDependencies) =>
+  async (command: CreateSourceCommand): Promise<CreateSourceResult> => {
+    const writeKey = generateWriteKey();
+    const writeKeyHash = await hashWriteKey(writeKey);
+
+    const initialSource = initializeSource(toInitializeSourceProps(command, writeKeyHash));
+
+    const sourceResult = await insertSource(initialSource);
+    if (isErr(sourceResult)) return sourceResult;
+
+    const source = sourceResult.value;
+
+    return ok({
+      id: source.id,
+      workspaceId: source.workspaceId,
+      name: source.name,
+      description: source.description,
+      appIdentifier: source.appIdentifier,
+      writeKey,
+    });
+  };

--- a/src/kairos/source/create-source/insert-source.type.ts
+++ b/src/kairos/source/create-source/insert-source.type.ts
@@ -1,0 +1,8 @@
+import type { Result } from '@/kairos/shared/result/result.type';
+import type { SourceAppIdentifierConflictError } from '@/kairos/source/domain/errors';
+import type { InitialSource } from '@/kairos/source/domain/initialize-source';
+import type { Source } from '@/kairos/source/domain/source.type';
+
+type InsertSourceResult = Result<Source, SourceAppIdentifierConflictError>;
+
+export type InsertSource = (source: InitialSource) => Promise<InsertSourceResult>;

--- a/src/kairos/source/domain/errors.ts
+++ b/src/kairos/source/domain/errors.ts
@@ -1,0 +1,6 @@
+export const sourceAppIdentifierConflictError = {
+  type: 'SOURCE_APP_IDENTIFIER_CONFLICT',
+  message: 'Source app identifier already exists in workspace',
+} as const;
+
+export type SourceAppIdentifierConflictError = typeof sourceAppIdentifierConflictError;

--- a/src/kairos/source/domain/initialize-source.test.ts
+++ b/src/kairos/source/domain/initialize-source.test.ts
@@ -1,0 +1,39 @@
+import { initializeSource } from '@/kairos/source/domain/initialize-source';
+import { describe, expect, test } from 'vitest';
+
+describe('Source', () => {
+  test('initializes source with description', () => {
+    const source = initializeSource({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: 'iOS app',
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+
+    expect(source).toEqual({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: 'iOS app',
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+  });
+
+  test('initializes source with null description when description is missing', () => {
+    const source = initializeSource({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+
+    expect(source).toEqual({
+      workspaceId: 'workspace-id',
+      name: 'Acme iOS',
+      description: null,
+      appIdentifier: 'com.acme.ios',
+      writeKeyHash: 'write-key-hash',
+    });
+  });
+});

--- a/src/kairos/source/domain/initialize-source.ts
+++ b/src/kairos/source/domain/initialize-source.ts
@@ -1,0 +1,19 @@
+import type { Source } from '@/kairos/source/domain/source.type';
+
+export type InitialSource = Readonly<Omit<Source, 'id'>>;
+
+export type InitializeSourceProps = Readonly<{
+  workspaceId: string;
+  name: string;
+  description?: string;
+  appIdentifier: string;
+  writeKeyHash: string;
+}>;
+
+export const initializeSource = (props: InitializeSourceProps): InitialSource => ({
+  workspaceId: props.workspaceId,
+  name: props.name,
+  description: props.description ?? null,
+  appIdentifier: props.appIdentifier,
+  writeKeyHash: props.writeKeyHash,
+});

--- a/src/kairos/source/domain/source.type.ts
+++ b/src/kairos/source/domain/source.type.ts
@@ -1,0 +1,8 @@
+export type Source = Readonly<{
+  id: string;
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  appIdentifier: string;
+  writeKeyHash: string;
+}>;

--- a/src/kairos/source/source-routes.ts
+++ b/src/kairos/source/source-routes.ts
@@ -1,0 +1,8 @@
+import { validateRequest } from '@/framework/http/validator';
+import { createSourceController } from '@/kairos/source/adapter/http/create-source/create-source-controller';
+import { createSourceRules } from '@/kairos/source/adapter/http/create-source/create-source-request';
+import { Post, RouteGroup } from '@koala-ts/framework/routing';
+
+export const sourceRoutes = RouteGroup({ prefix: '/workspaces/:workspaceId/sources', namePrefix: 'sources.' }, () => [
+  Post('/', 'create', validateRequest(createSourceRules), createSourceController),
+]);

--- a/tests/authentication/login.test.ts
+++ b/tests/authentication/login.test.ts
@@ -1,5 +1,5 @@
 import { appConfig } from '@/config';
-import { hashPassword } from '@/kairos/authentication/infrastructure/security/password/hash-password';
+import { hashPassword } from '@/framework/security/password';
 
 import { usersCollection } from '@/framework/mongodb/collection/users-collection';
 import { createTestAgent } from '@koala-ts/framework';

--- a/tests/source/create-source.test.ts
+++ b/tests/source/create-source.test.ts
@@ -1,0 +1,166 @@
+import { appConfig } from '@/config';
+
+import { sourcesCollection } from '@/framework/mongodb/collection/sources-collection';
+import { workspacesCollection } from '@/framework/mongodb/collection/workspaces-collection';
+import { createTestAgent } from '@koala-ts/framework';
+import { integrationTest } from '@tests/__vitest__/integration-test';
+import { ObjectId } from 'mongodb';
+import { describe, expect, test } from 'vitest';
+
+type SourceResponseFields = {
+  appIdentifier: string;
+  description?: string;
+  name: string;
+  workspaceId: string;
+};
+
+async function createWorkspace(name = 'Acme', slug = 'acme'): Promise<string> {
+  const inserted = await workspacesCollection.insertOne({
+    environments: ['default'],
+    name,
+    slug,
+  });
+
+  return inserted.insertedId.toHexString();
+}
+
+async function expectSourceCreated(response: { status: number; body: unknown }, expectedSource: SourceResponseFields) {
+  const persistedSource = await sourcesCollection.findOne({
+    app_identifier: expectedSource.appIdentifier,
+    workspace_id: new ObjectId(expectedSource.workspaceId),
+  });
+
+  expect(response.status).toBe(201);
+  expect(response.body).toEqual({
+    data: {
+      id: expect.any(String),
+      ...expectedSource,
+      description: expectedSource.description ?? null,
+      writeKey: expect.any(String),
+    },
+  });
+  expect(response.body).not.toHaveProperty('data.writeKeyHash');
+  expect(persistedSource).toEqual(
+    expect.objectContaining({
+      app_identifier: expectedSource.appIdentifier,
+      name: expectedSource.name,
+      workspace_id: new ObjectId(expectedSource.workspaceId),
+      write_key_hash: expect.any(String),
+    }),
+  );
+  expect(persistedSource).not.toHaveProperty('write_key');
+
+  if (expectedSource.description === undefined) {
+    expect(persistedSource).toEqual(expect.objectContaining({ description: null }));
+
+    return;
+  }
+
+  expect(persistedSource).toEqual(expect.objectContaining({ description: expectedSource.description }));
+}
+
+describe('Source feature test', () => {
+  integrationTest();
+
+  describe('creating a source', () => {
+    test('it should create source', async () => {
+      const agent = createTestAgent(appConfig);
+      const workspaceId = await createWorkspace();
+      const payload = {
+        name: 'Acme iOS',
+        description: 'iOS app',
+        appIdentifier: 'com.acme.ios',
+      };
+
+      const response = await agent.post(`/api/v1/workspaces/${workspaceId}/sources`).send(payload);
+
+      await expectSourceCreated(response, {
+        workspaceId,
+        name: 'Acme iOS',
+        description: 'iOS app',
+        appIdentifier: 'com.acme.ios',
+      });
+    });
+
+    test('it should create source without description', async () => {
+      const agent = createTestAgent(appConfig);
+      const workspaceId = await createWorkspace();
+      const payload = {
+        name: 'Acme Android',
+        appIdentifier: 'com.acme.android',
+      };
+
+      const response = await agent.post(`/api/v1/workspaces/${workspaceId}/sources`).send(payload);
+
+      await expectSourceCreated(response, {
+        workspaceId,
+        name: 'Acme Android',
+        appIdentifier: 'com.acme.android',
+      });
+    });
+  });
+
+  describe('conflicts', () => {
+    test('it should reject duplicate app identifier in same workspace', async () => {
+      const agent = createTestAgent(appConfig);
+      const workspaceId = await createWorkspace();
+      await sourcesCollection.insertOne({
+        workspace_id: new ObjectId(workspaceId),
+        name: 'Acme iOS',
+        description: null,
+        app_identifier: 'com.acme.app',
+        write_key_hash: 'hashed-write-key',
+      });
+      const payload = {
+        name: 'Acme Android',
+        appIdentifier: 'com.acme.app',
+      };
+
+      const response = await agent.post(`/api/v1/workspaces/${workspaceId}/sources`).send(payload);
+
+      expect(response.status).toBe(409);
+      expect(response.body).toEqual({
+        type: 'SOURCE_APP_IDENTIFIER_CONFLICT',
+        message: 'Source app identifier already exists in workspace',
+      });
+    });
+
+    test('it should allow same app identifier in different workspaces', async () => {
+      const agent = createTestAgent(appConfig);
+      const firstWorkspaceId = await createWorkspace('Acme', 'acme');
+      const secondWorkspaceId = await createWorkspace('Globex', 'globex');
+      await sourcesCollection.insertOne({
+        workspace_id: new ObjectId(firstWorkspaceId),
+        name: 'Acme iOS',
+        description: null,
+        app_identifier: 'com.acme.app',
+        write_key_hash: 'hashed-write-key',
+      });
+      const payload = {
+        name: 'Globex iOS',
+        appIdentifier: 'com.acme.app',
+      };
+
+      const response = await agent.post(`/api/v1/workspaces/${secondWorkspaceId}/sources`).send(payload);
+
+      await expectSourceCreated(response, {
+        workspaceId: secondWorkspaceId,
+        name: 'Globex iOS',
+        appIdentifier: 'com.acme.app',
+      });
+    });
+  });
+
+  describe('request validation', () => {
+    test('it should validate create source request', async () => {
+      const agent = createTestAgent(appConfig);
+      const workspaceId = await createWorkspace();
+
+      const response = await agent.post(`/api/v1/workspaces/${workspaceId}/sources`).send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.errors).toHaveProperty('name', ['This value should not be blank.']);
+      expect(response.body.errors).toHaveProperty('appIdentifier', ['This value should not be blank.']);
+    });
+  });
+});


### PR DESCRIPTION
| Q       | A                      |
| ------- | ---------------------- |
| License | GPLv3                  |
| Issue   | Closes #72 

This pull request introduces the initial implementation of the "Source" entity and its creation workflow, including database schema, HTTP API endpoint, business logic, and supporting utilities. It also refactors password hashing utilities for broader reuse.